### PR TITLE
Created SpecUtil to handle common api request config and common assertion

### DIFF
--- a/clear
+++ b/clear
@@ -1,0 +1,42 @@
+[33mcommit 7ddeafadda87ec83c2883615fca224184fd82a61[m[33m ([m[1;36mHEAD[m[33m -> [m[1;32mmaster[m[33m)[m
+Author: sailesh123kumar <saileshkumar17893@gmail.com>
+Date:   Tue Sep 30 21:26:54 2025 +0530
+
+    Requirement 4 :
+    
+    testng.xml file created and added maven surefire plugin to pass the
+    suiteXmlFile parameter
+
+[33mcommit dea4c1b76241e59e42a1fba1932da345fd22d3bf[m
+Author: sailesh123kumar <saileshkumar17893@gmail.com>
+Date:   Mon Sep 29 10:31:57 2025 +0530
+
+    Requirement 3 : CountAPI and MasterAPI Test
+    
+    Role : Hold all the user for Roles of Phoenix application
+    
+    UserDetailAPITest : Functional API Test Checks the status code ,response
+    time and schema. Also does the negative test for token
+    
+    CountAPITest : Functional API Test Checks the status code , response
+    time and schema. Also does the negative test for token
+    
+    MasterAPITest : Functional API Test Checks the status code , response
+    time and schema. Also does the negative test for token
+
+[33mcommit 9205b8add1fc4a0837143483988c6d1fdf5b7074[m
+Author: sailesh123kumar <saileshkumar17893@gmail.com>
+Date:   Sun Sep 28 17:39:50 2025 +0530
+
+    Created Config Manager Class for Managing the multiple environments
+    (dev,qa,uat) for the projects
+    
+    Updated pom.xml file -
+    maven.compiler.source - 14
+    maven.compiler.target - 14
+
+[33mcommit 3c7a2d68c66914971036f0e9c90c815e95f9985b[m
+Author: sailesh123kumar <saileshkumar17893@gmail.com>
+Date:   Sun Sep 28 00:01:54 2025 +0530
+
+    Base Code for automation framework

--- a/src/test/java/com/api/test/CountAPITest.java
+++ b/src/test/java/com/api/test/CountAPITest.java
@@ -1,29 +1,33 @@
 package com.api.test;
 
-import static com.api.constants.Role.*;
-import static com.api.utils.AuthTokenProvider.*;
-import static com.api.utils.ConfigManager.*;
-import static io.restassured.RestAssured.*;
-import static org.hamcrest.Matchers.*;
+import static com.api.constants.Role.FD;
+import static com.api.utils.SpecUtil.request_Spec;
+import static com.api.utils.SpecUtil.request_SpecWithAuth;
+import static com.api.utils.SpecUtil.response_Spec_OK;
+import static io.restassured.RestAssured.given;
+import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import static org.hamcrest.Matchers.blankOrNullString;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
 import org.testng.annotations.Test;
 
-import static io.restassured.module.jsv.JsonSchemaValidator.*;
+import static com.api.utils.SpecUtil.*;
 
 public class CountAPITest {
 	
 	@Test
 	public void verifyCountAPIPositiveTest(){
 		given()
-			.baseUri(getProperty("BASE_URI"))
-			.header("Authorization",getToken(FD))
-			.log().uri()
-			.log().method()
+			.spec(request_SpecWithAuth(FD))
 		.when()
 			.get("dashboard/count")
 		.then()
-			.log().all()
-			.statusCode(200)
-			.time(lessThan(1500l))
+			.spec(response_Spec_OK())
 			.body("data", notNullValue())
 			.body("data.size()", equalTo(3))
 			.body("data.count", everyItem(greaterThanOrEqualTo(0)))
@@ -38,15 +42,11 @@ public class CountAPITest {
 	public void verifyMissingAuth_CountAPITest() {
 		
 		given()
-		.baseUri(getProperty("BASE_URI"))
-		.log().uri()
-		.log().method()
-		.log().method()
+		.spec(request_Spec())
 	.when()
 		.get("dashboard/count")
 	.then()
-		.log().all()
-		.statusCode(401);
+		.spec(response_Spec_With_Text_StatusCode(401));
 		
 	}
 

--- a/src/test/java/com/api/test/LogInAPITest.java
+++ b/src/test/java/com/api/test/LogInAPITest.java
@@ -1,17 +1,13 @@
 package com.api.test;
 
-import static com.api.utils.ConfigManager.*;
-import static io.restassured.RestAssured.*;
-
+import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
-
-import java.io.IOException;
 
 import org.testng.annotations.Test;
 
 import com.api.pojo.UserCredentials;
+import static com.api.utils.SpecUtil.*;
 
-import io.restassured.http.ContentType;
 import io.restassured.module.jsv.JsonSchemaValidator;
 
 public class LogInAPITest {
@@ -22,22 +18,11 @@ public class LogInAPITest {
 		UserCredentials userCredentials = new UserCredentials("iamfd","password");
 
 		given()
-			.baseUri(getProperty("BASE_URI"))
-			.and()
-			.contentType(ContentType.JSON)
-			.and()
-			.accept(ContentType.JSON)
-			.body(userCredentials)
-			.log().uri()
-			.log().method()
-			.log().headers()
-			.log().body()
+			.spec(request_Spec(userCredentials))
 		.when()
 			.post("login")
 		.then()
-			.log().all()
-			.statusCode(200)
-			.time(lessThan(1500l))
+			.spec(response_Spec_OK())
 			.body("message", equalTo("Success"))
 			.and()
 			.body(JsonSchemaValidator.matchesJsonSchemaInClasspath("response-schema/LoginResponseSchema.json"));

--- a/src/test/java/com/api/test/MasterAPITest.java
+++ b/src/test/java/com/api/test/MasterAPITest.java
@@ -1,14 +1,19 @@
 package com.api.test;
 
-import static org.hamcrest.Matchers.*;
+import static com.api.constants.Role.FD;
+import static com.api.utils.SpecUtil.request_Spec;
+import static com.api.utils.SpecUtil.request_SpecWithAuth;
+import static com.api.utils.SpecUtil.response_Spec_OK;
+import static com.api.utils.SpecUtil.response_Spec_With_Text_StatusCode;
+import static io.restassured.RestAssured.given;
+import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.notNullValue;
+
 import org.testng.annotations.Test;
-
-import static io.restassured.module.jsv.JsonSchemaValidator.*;
-import static com.api.constants.Role.*;
-import static com.api.utils.AuthTokenProvider.*;
-import static com.api.utils.ConfigManager.*;
-
-import static io.restassured.RestAssured.*;
 
 public class MasterAPITest {
 	
@@ -18,19 +23,11 @@ public class MasterAPITest {
 		//API Developed Incorrectly hen we are not passing any body , It supposed to be get request
 		
 		given()
-			.baseUri(getProperty("BASE_URI"))
-			.and()
-			.header("Authorization",getToken(FD))
-			.contentType("")  //default content-type application/url-form-encoded
-			.log().uri()
-			.log().method()
-			.log().headers()
+			.spec(request_SpecWithAuth(FD))
 		.when()
 			.post("master")
 		.then()
-			.log().all()
-			.statusCode(200)
-			.time(lessThan(1500l))
+			.spec(response_Spec_OK())
 			.body("$", hasKey("message"))
 			.body("$", hasKey("data"))
 			.body("message", equalTo("Success"))
@@ -50,17 +47,11 @@ public class MasterAPITest {
 	public void invalidTokenMasterAPITest() {
 		
 		given()
-		.baseUri(getProperty("BASE_URI"))
-		.and()
-		.contentType("")  //default content-type application/url-form-encoded
-		.log().uri()
-		.log().method()
-		.log().headers()
+		.spec(request_Spec())
 	.when()
 		.post("master")
 	.then()
-		.log().all()
-		.statusCode(401);
+		.spec(response_Spec_With_Text_StatusCode(401));
 		
 		
 	}

--- a/src/test/java/com/api/test/UserDetailsAPITest.java
+++ b/src/test/java/com/api/test/UserDetailsAPITest.java
@@ -1,37 +1,24 @@
 package com.api.test;
 
-import static com.api.utils.AuthTokenProvider.*;
-import static com.api.utils.ConfigManager.*;
-import static  io.restassured.RestAssured.*;
-import static org.hamcrest.Matchers.*;
-import org.testng.annotations.Test;
-import static com.api.constants.Role.*;
+import static com.api.constants.Role.FD;
+import static com.api.utils.SpecUtil.request_SpecWithAuth;
+import static com.api.utils.SpecUtil.response_Spec_OK;
+import static io.restassured.RestAssured.given;
+import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
 
-import io.restassured.http.ContentType;
-import io.restassured.http.Header;
-import static io.restassured.module.jsv.JsonSchemaValidator.*;
+import org.testng.annotations.Test;
 
 
 public class UserDetailsAPITest {
 
 	@Test
 	public void userDetailsAPITest() {
-		Header authHeader = new Header("Authorization",getToken(FD));
 		given()
-			.baseUri(getProperty("BASE_URI"))
-			.and()
-			.header(authHeader)
-			.and()
-			.accept(ContentType.JSON)
-			.log().uri()
-			.log().method()
-			.log().headers()
-			.log().body()
+			.spec(request_SpecWithAuth(FD))
 		.when()
 			.get("userdetails")
 		.then()
-			.statusCode(200)
-			.time(lessThan(1500l))
+			.spec(response_Spec_OK())
 			.and()
 			.body(matchesJsonSchemaInClasspath("response-schema/UserDetailsResponseSchema.json"))
 			.log().all();

--- a/src/test/java/com/api/utils/SpecUtil.java
+++ b/src/test/java/com/api/utils/SpecUtil.java
@@ -1,0 +1,109 @@
+package com.api.utils;
+
+import static com.api.utils.ConfigManager.getProperty;
+
+import org.hamcrest.Matchers;
+
+import com.api.constants.Role;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.builder.ResponseSpecBuilder;
+import io.restassured.filter.log.LogDetail;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseSpecification;
+
+public class SpecUtil {
+	
+	
+	// GET - DELETE
+	
+	public static RequestSpecification request_Spec() {
+		
+		RequestSpecification requestSpecification =  new RequestSpecBuilder()
+		.setBaseUri(getProperty("BASE_URI"))
+		.setContentType(ContentType.JSON)
+		.setAccept(ContentType.JSON)
+		.log(LogDetail.URI)
+		.log(LogDetail.METHOD)
+		.log(LogDetail.HEADERS)
+		.log(LogDetail.BODY)
+		.build();
+		
+		return requestSpecification;
+	}
+	
+	
+	public static RequestSpecification request_Spec(Object requestPayload) {
+		
+		RequestSpecification requestSpecification =  new RequestSpecBuilder()
+		.setBaseUri(getProperty("BASE_URI"))
+		.setContentType(ContentType.JSON)
+		.setAccept(ContentType.JSON)
+		.setBody(requestPayload)
+		.log(LogDetail.URI)
+		.log(LogDetail.METHOD)
+		.log(LogDetail.HEADERS)
+		.log(LogDetail.BODY)
+		.build();
+		
+		return requestSpecification;
+	}
+	
+	public static RequestSpecification request_SpecWithAuth(Role role) {
+		
+		RequestSpecification requestSpecification =  new RequestSpecBuilder()
+				.setBaseUri(getProperty("BASE_URI"))
+				.setContentType(ContentType.JSON)
+				.setAccept(ContentType.JSON)
+				.addHeader("Authorization", AuthTokenProvider.getToken(role))
+				.log(LogDetail.URI)
+				.log(LogDetail.METHOD)
+				.log(LogDetail.HEADERS)
+				.log(LogDetail.BODY)
+				.build();
+				
+				return requestSpecification;
+	}
+	
+	
+	
+	public static ResponseSpecification response_Spec_OK() {
+	
+		ResponseSpecification responseSpecification = new ResponseSpecBuilder()
+		.expectContentType(ContentType.JSON)
+		.expectStatusCode(200)
+		.expectResponseTime(Matchers.lessThan(2500L))
+		.log(LogDetail.ALL)
+		.build();
+		
+		return responseSpecification;
+	}
+	
+	public static ResponseSpecification response_Spec_WithStatusCode(int statusCode) {
+		
+		ResponseSpecification responseSpecification = new ResponseSpecBuilder()
+		.expectContentType(ContentType.JSON)
+		.expectStatusCode(statusCode)
+		.expectResponseTime(Matchers.lessThan(2500L))
+		.log(LogDetail.ALL)
+		.build();
+		
+		return responseSpecification;
+	}
+	
+public static ResponseSpecification response_Spec_With_Text_StatusCode(int statusCode) {
+		
+		ResponseSpecification responseSpecification = new ResponseSpecBuilder()
+		.expectStatusCode(statusCode)
+		.expectResponseTime(Matchers.lessThan(2500L))
+		.log(LogDetail.ALL)
+		.build();
+		
+		return responseSpecification;
+	}
+	
+	
+	
+
+}


### PR DESCRIPTION
SpecUtil is consistiong of common RequestSpecBuilder and ResponseSpecBuilder . These Util methods has reduced the boiler plate code in our api test and also reduced the number of lines. Making test code smaller and maintainable